### PR TITLE
✒️ [Refactor] Refresh token login 

### DIFF
--- a/lib/common/network/dio_client.dart
+++ b/lib/common/network/dio_client.dart
@@ -1,0 +1,151 @@
+import 'dart:async';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:team_project_front/common/const/base_url.dart';
+import 'package:team_project_front/common/utils/secure_storage_service.dart';
+
+// 컨텍스트 없이도 화면 전환을 하기 위한 글로벌 키
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+
+// 동시 refresh 방지 게이트
+class _RefreshGate {
+  // 현재 refresh 중인지 여부 플래그
+  bool _refreshing = false;
+  // 다른 요청들이 refresh 완료를 기다릴 수 있도록 하는 Completer
+  Completer<void>? _c;
+  Future<void> run(Future<void> Function() job) async {
+    if (_refreshing) return _c!.future;
+    _refreshing = true;
+    _c = Completer<void>();
+    try {
+      await job();
+      _c!.complete();
+    } catch (e) {
+      _c!.completeError(e);
+      rethrow;
+    } finally {
+      _refreshing = false;
+    }
+  }
+}
+
+final _refreshGate = _RefreshGate();
+
+Future<TokenPair?> _refreshTokens() async {
+  final refresh = await SecureStorageService.getRefreshToken();
+  if (refresh == null) return null;
+  final refreshDio = Dio(
+    BaseOptions(baseUrl: base_URL, connectTimeout: const Duration(seconds: 10)),
+  );
+  final res = await refreshDio.post(
+    '/auth/refresh',
+    data: {'refreshToken': refresh},
+    options: Options(validateStatus: (_) => true),
+  );
+  if (res.statusCode == 200) {
+    final result = res.data['result'] as Map<String, dynamic>;
+    final newAccess = result['accessToken'] as String;
+    final newRefresh = (result['refreshToken'] as String?) ?? refresh;
+    await SecureStorageService.saveAccessToken(newAccess);
+    await SecureStorageService.saveRefreshToken(newRefresh);
+    return TokenPair(newAccess, newRefresh);
+  }
+  return null;
+}
+
+class TokenPair {
+  final String access;
+  final String refresh;
+  TokenPair(this.access, this.refresh);
+}
+
+Dio buildAuthedDio() {
+  final dio = Dio(
+    BaseOptions(
+      baseUrl: base_URL,
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 10),
+    ),
+  );
+
+  dio.interceptors.clear();
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) async {
+        // refresh 호출은 건너뜀
+        final isRefreshCall = options.path.contains('/auth/refresh');
+        if (!isRefreshCall) {
+          final at = await SecureStorageService.getAccessToken();
+          if (at != null) {
+            options.headers['Authorization'] = 'Bearer $at';
+          }
+        }
+        handler.next(options);
+      },
+      onError: (error, handler) async {
+        final res = error.response;
+        final req = error.requestOptions;
+
+        // 이미 재시도한 요청이면 통과 (무한루프 방지)
+        if (req.extra['retried'] == true) return handler.next(error);
+
+        // 401이면 만료로 간주(가능하면 서버 code도 함께 체크)
+        final isExpired = res?.statusCode == 401;
+
+        if (isExpired) {
+          try {
+            await _refreshGate.run(() async {
+              final pair = await _refreshTokens();
+              if (pair == null) {
+                await SecureStorageService.clearTokens();
+                navigatorKey.currentState?.pushNamedAndRemoveUntil(
+                  '/login',
+                  (r) => false,
+                );
+                throw DioException(
+                  requestOptions: req,
+                  error: 'refresh failed',
+                );
+              }
+            });
+
+            // 새 토큰으로 원요청 재시도
+            final newAccess = await SecureStorageService.getAccessToken();
+            final newReq = _cloneWithNewToken(req, newAccess);
+            final resp = await dio.fetch(newReq);
+            return handler.resolve(resp);
+          } catch (_) {
+            // refresh 실패 → 원 에러 전달
+            return handler.next(error);
+          }
+        }
+
+        handler.next(error);
+      },
+    ),
+  );
+
+  return dio;
+}
+
+RequestOptions _cloneWithNewToken(RequestOptions req, String? access) {
+  final headers = Map<String, dynamic>.from(req.headers);
+  if (access != null) headers['Authorization'] = 'Bearer $access';
+
+  return RequestOptions(
+    path: req.path,
+    method: req.method,
+    baseUrl: req.baseUrl,
+    data: req.data,
+    queryParameters: req.queryParameters,
+    headers: headers,
+    connectTimeout: req.connectTimeout,
+    sendTimeout: req.sendTimeout,
+    receiveTimeout: req.receiveTimeout,
+    extra: Map<String, dynamic>.from(req.extra)..['retried'] = true,
+    contentType: req.contentType,
+    responseType: req.responseType,
+    followRedirects: req.followRedirects,
+    listFormat: req.listFormat,
+  );
+}

--- a/lib/common/utils/secure_storage_service.dart
+++ b/lib/common/utils/secure_storage_service.dart
@@ -16,10 +16,6 @@ class SecureStorageService {
     return await _storage.read(key: SecureStorageKey.accessToken);
   }
 
-  static Future<void> deleteAccessToken() async {
-    await _storage.delete(key: SecureStorageKey.accessToken);
-  }
-
   static Future<void> saveRefreshToken(String token) async {
     await _storage.write(key: SecureStorageKey.refreshToken, value: token);
   }
@@ -28,7 +24,8 @@ class SecureStorageService {
     return await _storage.read(key: SecureStorageKey.refreshToken);
   }
 
-  static Future<void> deleteRefreshToken() async {
+  static Future<void> clearTokens() async {
+    await _storage.delete(key: SecureStorageKey.accessToken);
     await _storage.delete(key: SecureStorageKey.refreshToken);
   }
 }

--- a/lib/home/view/body_temperature_graph.dart
+++ b/lib/home/view/body_temperature_graph.dart
@@ -4,9 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/custom_navigation_bar.dart';
 import 'package:team_project_front/common/component/temperature_chart_widget.dart';
 import 'package:intl/intl.dart';
-import 'package:team_project_front/common/const/base_url.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
 import 'package:team_project_front/homecam/model/home_cam.dart';
 
@@ -35,7 +34,7 @@ class _BodyTemperatureGraphScreenState
   @override
   void initState() {
     super.initState();
-    // ✅ 진입 시 홈캠/그래프 로드
+    // 진입 시 홈캠/그래프 로드
     fetchHomecams();
   }
 
@@ -43,13 +42,9 @@ class _BodyTemperatureGraphScreenState
     try {
       setState(() => _isLoading = true);
 
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
+      final dio = buildAuthedDio();
 
-      final res = await dio.get(
-        '$base_URL/homecams/list',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final res = await dio.get('/homecams/list');
 
       if (res.statusCode == 200) {
         final data = res.data['result'];
@@ -81,14 +76,8 @@ class _BodyTemperatureGraphScreenState
   Future<void> fetchGraph(int homecamId) async {
     try {
       setState(() => _isLoading = true);
-
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-
-      final res = await dio.get(
-        '$base_URL/homecams/graph/$homecamId',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+      final res = await dio.get('/homecams/graph/$homecamId');
 
       if (res.statusCode == 200) {
         final graphData = res.data['result'] as Map<String, dynamic>;

--- a/lib/home/view/home.dart
+++ b/lib/home/view/home.dart
@@ -1,9 +1,8 @@
-import 'package:dio/dio.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart'; // ⬅ 추가
-import 'package:team_project_front/common/const/base_url.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:team_project_front/common/const/colors.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/home/component/body_temperature_card.dart';
 import 'package:team_project_front/home/component/environment_card.dart';
 import 'package:team_project_front/home/component/fever_report_card.dart';
@@ -37,24 +36,35 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   void initState() {
     super.initState();
+    _requestNotificationPermission();
     _bootstrap();
+  }
+
+  Future<void> _requestNotificationPermission() async {
+    // 포그라운드 표시 옵션(iOS)
+    await FirebaseMessaging.instance
+        .setForegroundNotificationPresentationOptions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+
+    // 토큰 확인(테스트용)
+    final token = await FirebaseMessaging.instance.getToken();
+    print('FCM token: $token');
+
+    FirebaseMessaging.onMessage.listen((message) {
+      print('onMessage: ${message.notification?.title}');
+    });
   }
 
   Future<RoomCondition?> fetchRoomConditionData(int childId) async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-      final res = await dio.get(
-        '$base_URL/rooms/$childId',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+      final res = await dio.get('/rooms/$childId');
       if (res.statusCode == 200) {
         final data = (res.data['result'] ?? {}) as Map<String, dynamic>;
-        return RoomCondition(
-          airTemperature: (data['temperature'] as num?)?.toDouble(),
-          humidity: (data['humidity'] as num?)?.toDouble(),
-          createdAt: DateTime.tryParse(data['createdAt'] as String? ?? ''),
-        );
+        return RoomCondition.fromJson(data);
       }
       return null;
     } catch (_) {
@@ -64,12 +74,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   Future<FeverRecord?> fetchFeverRecordData(int childId) async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-      final res = await dio.get(
-        '$base_URL/feverRecords/$childId',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+      final res = await dio.get('/feverRecords/$childId');
+
       if (res.statusCode == 200) {
         final data = (res.data['result'] ?? {}) as Map<String, dynamic>;
         final fever = (data['fever'] as num?)?.toDouble();
@@ -87,12 +94,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   }
 
   Future<List<Baby>> fetchBabiesData() async {
-    final dio = Dio();
-    final token = await SecureStorageService.getAccessToken();
-    final res = await dio.get(
-      '$base_URL/children',
-      options: Options(headers: {'Authorization': 'Bearer $token'}),
-    );
+    final dio = buildAuthedDio();
+    final res = await dio.get('/children');
     if (res.statusCode == 200) {
       final list = List<Map<String, dynamic>>.from(res.data['result']);
       return list
@@ -112,12 +115,8 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
 
   Future<Baby?> fetchBabyData(int childId) async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-      final res = await dio.get(
-        '$base_URL/children/$childId',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+      final res = await dio.get('/children/$childId');
       if (res.statusCode == 200) {
         final m = res.data['result'] as Map<String, dynamic>;
         return Baby(

--- a/lib/home/view/room_teperature_humidity_graph.dart
+++ b/lib/home/view/room_teperature_humidity_graph.dart
@@ -4,9 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:team_project_front/common/component/custom_navigation_bar.dart';
 import 'package:team_project_front/common/component/temperature_chart_widget.dart';
-import 'package:team_project_front/common/const/base_url.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
 import 'package:team_project_front/homecam/model/home_cam.dart';
 
@@ -46,13 +45,9 @@ class _RoomTemperatureHumidityGraphScreenState
     try {
       setState(() => _isLoading = true);
 
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
+      final dio = buildAuthedDio();
 
-      final res = await dio.get(
-        '$base_URL/homecams/list',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final res = await dio.get('/homecams/list');
 
       if (res.statusCode == 200) {
         final data = res.data['result'];
@@ -85,13 +80,9 @@ class _RoomTemperatureHumidityGraphScreenState
     try {
       setState(() => _isLoading = true);
 
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
+      final dio = buildAuthedDio();
 
-      final res = await dio.get(
-        '$base_URL/homecams/graph/$homecamId',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final res = await dio.get('/homecams/graph/$homecamId');
 
       if (res.statusCode == 200) {
         final graphData = res.data['result'] as Map<String, dynamic>;

--- a/lib/homecam/component/home_cam_form.dart
+++ b/lib/homecam/component/home_cam_form.dart
@@ -2,10 +2,9 @@ import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/custom_input.dart';
 import 'package:team_project_front/common/component/navigation_button.dart';
-import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/model/baby.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/mypage/view/add_profile_screen.dart';
 
 class HomeCamForm extends StatefulWidget {
@@ -47,13 +46,8 @@ class _HomeCamFormState extends State<HomeCamForm> {
   // 추후 캐싱 이용하면 좋을듯
   Future<void> fetchBabies() async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-
-      final res = await dio.get(
-        '$base_URL/children',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+      final res = await dio.get('/children');
 
       if (res.statusCode == 200) {
         final data = List<Map<String, dynamic>>.from(res.data['result']);

--- a/lib/homecam/component/home_cam_view.dart
+++ b/lib/homecam/component/home_cam_view.dart
@@ -1,9 +1,7 @@
-import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:flutter_mjpeg/flutter_mjpeg.dart';
-import 'package:team_project_front/common/const/base_url.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/home/model/fever_record_data.dart';
 import 'package:team_project_front/home/model/room_condition.dart';
 import 'package:team_project_front/homecam/component/state_info_card.dart';
@@ -56,12 +54,9 @@ class _HomeCamViewState extends State<HomeCamView> {
 
   Future<RoomCondition?> fetchRoomConditionData(int childId) async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-      final res = await dio.get(
-        '$base_URL/rooms/$childId',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+
+      final res = await dio.get('/rooms/$childId');
       if (res.statusCode == 200) {
         final data = (res.data['result'] ?? {}) as Map<String, dynamic>;
         return RoomCondition(
@@ -78,12 +73,9 @@ class _HomeCamViewState extends State<HomeCamView> {
 
   Future<FeverRecord?> fetchFeverRecordData(int childId) async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-      final res = await dio.get(
-        '$base_URL/feverRecords/$childId',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+
+      final res = await dio.get('/feverRecords/$childId');
       if (res.statusCode == 200) {
         final data = (res.data['result'] ?? {}) as Map<String, dynamic>;
         final fever = (data['fever'] as num?)?.toDouble();

--- a/lib/homecam/component/state_info_card.dart
+++ b/lib/homecam/component/state_info_card.dart
@@ -25,8 +25,8 @@ class StatInfoCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final baseColor = color ?? theme.colorScheme.primary;
-    final bg = baseColor.withOpacity(0.08);
-    final iconBg = baseColor.withOpacity(0.15);
+    final bg = baseColor.withValues(alpha: 0.08);
+    final iconBg = baseColor.withValues(alpha: 0.15);
 
     Widget body;
     if (isLoading) {

--- a/lib/homecam/view/create_home_cam.dart
+++ b/lib/homecam/view/create_home_cam.dart
@@ -1,8 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:team_project_front/common/const/base_url.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
 import 'package:team_project_front/homecam/component/home_cam_form.dart';
 import 'package:team_project_front/homecam/view/create_home_cam_complete.dart';
@@ -40,18 +39,16 @@ class _CreateHomeCamScreenState extends State<CreateHomeCamScreen> {
 
   Future<void> createHomeCam() async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
+      final dio = buildAuthedDio();
 
       final res = await dio.post(
-        '$base_URL/homecams',
+        '/homecams',
         data: {
           'childId': int.parse(selectedChild!),
           'serial_num': homeCamSerialNumController.text.trim(),
           'name': nameController.text.trim(),
           'place': installationPlaceController.text.trim(),
         },
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
       );
 
       if (res.statusCode == 200) {

--- a/lib/homecam/view/delete_home_cam.dart
+++ b/lib/homecam/view/delete_home_cam.dart
@@ -1,9 +1,8 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
 
 class DeleteHomeCamScreen extends StatefulWidget {
   const DeleteHomeCamScreen({
@@ -27,12 +26,8 @@ class _DeleteHomeCamScreenState extends State<DeleteHomeCamScreen> {
     setState(() => _isDeleting = true);
 
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-      final res = await dio.delete(
-        '$base_URL/homecams/${widget.homeCamId}',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+      final res = await dio.delete('/homecams/${widget.homeCamId}');
 
       if (!mounted) return;
 

--- a/lib/homecam/view/home_cam.dart
+++ b/lib/homecam/view/home_cam.dart
@@ -1,7 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:team_project_front/common/const/base_url.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
 import 'package:team_project_front/homecam/component/home_cam_view.dart';
 import 'package:team_project_front/homecam/model/home_cam.dart';
@@ -28,13 +27,9 @@ class _HomeCamScreenState extends State<HomeCamScreen> {
 
   Future<void> _fetchDetail() async {
     try {
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
+      final dio = buildAuthedDio();
 
-      final res = await dio.get(
-        '$base_URL/homecams/${widget.homeCamId}',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final res = await dio.get('/homecams/${widget.homeCamId}');
 
       if (!mounted) return;
 

--- a/lib/homecam/view/home_cam_list.dart
+++ b/lib/homecam/view/home_cam_list.dart
@@ -1,9 +1,8 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
-import 'package:team_project_front/common/const/base_url.dart';
 import 'package:team_project_front/common/const/colors.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
 import 'package:team_project_front/homecam/component/no_home_cam_view.dart';
 import 'package:team_project_front/homecam/model/home_cam.dart';
 import 'package:team_project_front/homecam/view/create_home_cam.dart';
@@ -29,12 +28,8 @@ class _HomeCamListScreenState extends State<HomeCamListScreen> {
 
   Future<void> _fetchHomeCams() async {
     try {
-      final Dio dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
-      final res = await dio.get(
-        '$base_URL/homecams/list',
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
-      );
+      final dio = buildAuthedDio();
+      final res = await dio.get('/homecams/list');
 
       if (!mounted) return;
 

--- a/lib/homecam/view/update_home_cam.dart
+++ b/lib/homecam/view/update_home_cam.dart
@@ -1,8 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:team_project_front/common/component/custom_navigation_bar.dart';
-import 'package:team_project_front/common/const/base_url.dart';
-import 'package:team_project_front/common/utils/secure_storage_service.dart';
+import 'package:team_project_front/common/network/dio_client.dart';
 import 'package:team_project_front/common/utils/error_dialog.dart';
 import 'package:team_project_front/common/view/root_tab.dart';
 import 'package:team_project_front/homecam/component/home_cam_form.dart';
@@ -70,17 +69,16 @@ class _UpdateHomeCamScreenState extends State<UpdateHomeCamScreen> {
         return;
       }
 
-      final dio = Dio();
-      final token = await SecureStorageService.getAccessToken();
+      final dio = buildAuthedDio();
+
       final res = await dio.patch(
-        '$base_URL/homecams/${widget.homeCamId}',
+        '/homecams/${widget.homeCamId}',
         data: {
           'childId': int.parse(selectedChild!),
           'serialNum': homeCamSerialNumController.text.trim(),
           'name': nameController.text.trim(),
           'place': installationPlaceController.text.trim(),
         },
-        options: Options(headers: {'Authorization': 'Bearer $token'}),
       );
 
       if (!mounted) return;

--- a/lib/login/view/login.dart
+++ b/lib/login/view/login.dart
@@ -34,37 +34,67 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _isObscure = true;
 
   Future<void> _login() async {
-    if (_formKey.currentState!.validate()) {
-      try {
-        final dio = Dio();
+    if (!_formKey.currentState!.validate()) return;
 
-        final res = await dio.post(
-          '$base_URL/auth/login',
-          data: {
-            'email': _idController.text.trim(),
-            'password': _passwordController.text,
-          },
-        );
-        if (res.statusCode == 200) {
-          final accessToken = res.data['result']['accessToken'];
-          final refreshToken = res.data['result']['refreshToken'];
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: base_URL,
+        connectTimeout: const Duration(seconds: 10),
+        receiveTimeout: const Duration(seconds: 10),
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+        },
+        validateStatus: (_) => true,
+      ),
+    );
 
-          await SecureStorageService.saveAccessToken(accessToken);
-          await SecureStorageService.saveRefreshToken(refreshToken);
-          if (!mounted) return;
-          Navigator.pushNamedAndRemoveUntil(context, '/home', (route) => false);
-        } else {
-          if (!mounted) return;
-          showErrorDialog(context: context, message: '로그인에 실패했습니다.');
-        }
-      } on DioException catch (err) {
-        String message = '알 수 없는 오류가 발생했습니다.';
-        if (err.response != null && err.response?.data != null) {
-          message = err.response?.data['message'] ?? message;
-        }
+    try {
+      final res = await dio.post(
+        '/auth/login',
+        data: {
+          'email': _idController.text.trim(),
+          'password': _passwordController.text,
+        },
+      );
+
+      final sc = res.statusCode ?? 0;
+      if (sc < 200 || sc >= 300) {
+        final serverMsg = (res.data is Map) ? res.data['message'] : null;
         if (!mounted) return;
-        showErrorDialog(context: context, message: message);
+        return showErrorDialog(
+          context: context,
+          message: serverMsg ?? '로그인 실패 (HTTP $sc)',
+        );
       }
+
+      final result =
+          (res.data is Map)
+              ? res.data['result'] as Map<String, dynamic>?
+              : null;
+      final String? accessToken = result?['accessToken'] as String?;
+      final String? refreshToken = result?['refreshToken'] as String?;
+      if (accessToken == null || refreshToken == null) {
+        if (!mounted) return;
+        return showErrorDialog(context: context, message: '응답에 토큰 정보가 없습니다.');
+      }
+
+      await SecureStorageService.saveAccessToken(accessToken);
+      await SecureStorageService.saveRefreshToken(refreshToken);
+
+      if (!mounted) return;
+      Navigator.pushNamedAndRemoveUntil(context, '/home', (route) => false);
+    } on DioException catch (e) {
+      final serverMsg =
+          (e.response?.data is Map) ? e.response?.data['message'] : null;
+      if (!mounted) return;
+      showErrorDialog(
+        context: context,
+        message: serverMsg ?? '네트워크 오류가 발생했습니다.',
+      );
+    } catch (e) {
+      if (!mounted) return;
+      showErrorDialog(context: context, message: '알 수 없는 오류가 발생했습니다.');
     }
   }
 
@@ -77,8 +107,11 @@ class _LoginScreenState extends State<LoginScreen> {
         data: {'provider': provider, 'accessToken': accessToken},
       );
       if (res.statusCode == 200) {
-        final token = res.data['result']['accessToken'];
-        await SecureStorageService.saveAccessToken(token);
+        final accessToken = res.data['result']['accessToken'];
+        final refreshToken = res.data['result']['refreshToken'];
+
+        await SecureStorageService.saveAccessToken(accessToken);
+        await SecureStorageService.saveRefreshToken(refreshToken);
 
         if (!mounted) return;
         Navigator.pushNamedAndRemoveUntil(context, '/home', (route) => false);

--- a/lib/settings/view/settings_screen.dart
+++ b/lib/settings/view/settings_screen.dart
@@ -25,41 +25,38 @@ class SettingsScreen extends StatelessWidget {
     return Scaffold(
       appBar: PreferredSize(
         preferredSize: Size.fromHeight(90),
-        child: CustomAppbar(
-          title: '설정',
-        ),
+        child: CustomAppbar(title: '설정'),
       ),
-      body: _SettingsListView(
-          settingsItems: settingsItems,
-      ),
+      body: _SettingsListView(settingsItems: settingsItems),
     );
   }
 
   void onPressedTerms(BuildContext context) {
-    Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) => TermsScreen()),
-    );
+    Navigator.of(
+      context,
+    ).push(MaterialPageRoute(builder: (context) => TermsScreen()));
   }
-  
+
   void onPressedNotification(BuildContext context) {
     Navigator.of(context).push(
-      MaterialPageRoute(builder: (context) => NotificationSettingsScreen())
+      MaterialPageRoute(builder: (context) => NotificationSettingsScreen()),
     );
   }
 
   void onPressedLogout(BuildContext context) {
     showDialog(
       context: context,
-      builder: (context) => YesOrNoDialog(
-        title: '로그아웃',
-        content: '정말 로그아웃 하시겠습니까?',
-        onPressedYes: () async {
-          Navigator.of(context).pop();
-          await logoutUser();
-        },
-        yesText: '예',
-        noText: '아니오',
-      ),
+      builder:
+          (context) => YesOrNoDialog(
+            title: '로그아웃',
+            content: '정말 로그아웃 하시겠습니까?',
+            onPressedYes: () async {
+              Navigator.of(context).pop();
+              await logoutUser();
+            },
+            yesText: '예',
+            noText: '아니오',
+          ),
     );
   }
 
@@ -77,23 +74,20 @@ class SettingsScreen extends StatelessWidget {
     try {
       final response = await dio.post(
         '$base_URL/auth/logout',
-        options: Options(headers: {
-          'Authorization': accessToken,
-        }),
+        options: Options(headers: {'Authorization': accessToken}),
       );
 
       if (response.data['isSuccess'] == true) {
-        await SecureStorageService.deleteAccessToken();
-        // refreshToken 관련 로직 추가 예정
+        await SecureStorageService.clearTokens();
 
         navigatorKey.currentState?.pushNamedAndRemoveUntil(
           '/login',
-              (route) => false,
+          (route) => false,
         );
       } else {
         print('로그아웃 실패: ${response.data['message']}');
       }
-    } catch(e) {
+    } catch (e) {
       print('로그아웃 오류: $e');
     }
   }
@@ -101,19 +95,20 @@ class SettingsScreen extends StatelessWidget {
   void onPressedWithdraw(BuildContext context) {
     showDialog(
       context: context,
-      builder: (context) => YesOrNoDialog(
-        title: '회원 탈퇴',
-        content:
-          '회원 탈퇴 시 기록하신 모든 데이터가\n'
-          '삭제되어 복구가 불가능합니다.\n'
-          '정말 탈퇴하시겠습니까?',
-        onPressedYes: () async {
-          Navigator.of(context).pop();
-          await withdrawUser();
-        },
-        yesText: '예',
-        noText: '아니오',
-      ),
+      builder:
+          (context) => YesOrNoDialog(
+            title: '회원 탈퇴',
+            content:
+                '회원 탈퇴 시 기록하신 모든 데이터가\n'
+                '삭제되어 복구가 불가능합니다.\n'
+                '정말 탈퇴하시겠습니까?',
+            onPressedYes: () async {
+              Navigator.of(context).pop();
+              await withdrawUser();
+            },
+            yesText: '예',
+            noText: '아니오',
+          ),
     );
   }
 }
@@ -132,20 +127,19 @@ Future<void> withdrawUser() async {
   try {
     final response = await dio.delete(
       '$base_URL/my',
-      options: Options(headers: {
-        'Authorization': accessToken,
-      }),
+      options: Options(headers: {'Authorization': accessToken}),
     );
 
     if (response.data['isSuccess'] == true) {
-      await SecureStorageService.deleteAccessToken();
-      // refreshToken 관련 로직 추가 예정
-
-      navigatorKey.currentState?.pushNamedAndRemoveUntil('/login', (route) => false);
+      await SecureStorageService.clearTokens();
+      navigatorKey.currentState?.pushNamedAndRemoveUntil(
+        '/login',
+        (route) => false,
+      );
     } else {
       print('탈퇴 실패: ${response.data['message']}');
     }
-  } catch(e) {
+  } catch (e) {
     print('회원 탈퇴 오류: $e');
   }
 }
@@ -153,10 +147,7 @@ Future<void> withdrawUser() async {
 class _SettingsListView extends StatelessWidget {
   final List<Map<String, dynamic>> settingsItems;
 
-  const _SettingsListView({
-    required this.settingsItems,
-    super.key,
-  });
+  const _SettingsListView({required this.settingsItems});
 
   @override
   Widget build(BuildContext context) {
@@ -168,34 +159,27 @@ class _SettingsListView extends StatelessWidget {
 
         return Column(
           children: [
-            Divider(
-              color: ICON_GREY_COLOR,
-              height: 0.5,
-              thickness: 1,
-            ),
+            Divider(color: ICON_GREY_COLOR, height: 0.5, thickness: 1),
             ListTile(
               title: Text(
                 item['title'],
-                style: TextStyle(
-                  fontWeight: FontWeight.w500,
-                ),
+                style: TextStyle(fontWeight: FontWeight.w500),
               ),
-              trailing: item['trailing'] != null ? Text(
-                item['trailing'],
-                style: TextStyle(
-                    fontWeight: FontWeight.w700,
-                    color: ICON_GREY_COLOR,
-                    fontSize: 15
-                ),
-              ) : null,
+              trailing:
+                  item['trailing'] != null
+                      ? Text(
+                        item['trailing'],
+                        style: TextStyle(
+                          fontWeight: FontWeight.w700,
+                          color: ICON_GREY_COLOR,
+                          fontSize: 15,
+                        ),
+                      )
+                      : null,
               onTap: item['onTap'],
             ),
-            Divider(
-              color: ICON_GREY_COLOR,
-              height: 0.5,
-              thickness: 1,
-            ),
-            if(item['title'] == '로그아웃' || item['title'] == '버전 정보')
+            Divider(color: ICON_GREY_COLOR, height: 0.5, thickness: 1),
+            if (item['title'] == '로그아웃' || item['title'] == '버전 정보')
               SizedBox(height: 64),
           ],
         );


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용

- 기존 access token만 사용했던 로그인 로직 refresh token도 같이 받도록 수정,
- 기존 API 호출 Dio 인스턴스 생성하던 방식을 buildAuthedDio을 통해 토큰 검증 및 access token 만료시 재발급 하도록 수정
- API 호출시 Dio 대신에 buildAuthedDio를 사용하면서 기존 코드를 좀 더 간략하게 만들고 토큰 재발급도 자동적으로 진행하도록 수정했습니다.
- 기존에 제가 작업한 부분만 수정해 뒀으니 강민님도 제 코드 참고해 수정하시면 될 거 같습니다.



## ➕ 이슈 링크

- closes #64 

<br/>
